### PR TITLE
Ryzxxn gpio fix (AEGHB-1345)

### DIFF
--- a/components/iot_bridge/src/bridge_eth.c
+++ b/components/iot_bridge/src/bridge_eth.c
@@ -16,8 +16,8 @@
 #include "freertos/task.h"
 #include "freertos/FreeRTOS.h"
 
-#if CONFIG_BRIDGE_USE_SPI_ETHERNET
 #include "driver/gpio.h"
+#if CONFIG_BRIDGE_USE_SPI_ETHERNET
 #include "driver/spi_master.h"
 #endif
 


### PR DESCRIPTION
The source file `src/bridge_eth.c` includes `driver/gpio.h` to handle Ethernet PHY configuration. Previously, the build failed because the `driver` component was missing from the CMake `REQUIRES` list, preventing 
the compiler from resolving the header file.

This commit adds `driver` to the component requirements to ensure dependencies are correctly linked and the header can be found.