### PR TITLE
Add esp_driver_gpio to iot_bridge requires (AEGHB-1446)

### DIFF
--- a/components/iot_bridge/CMakeLists.txt
+++ b/components/iot_bridge/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(srcs "src/bridge_common.c" "src/bridge_lwip_hook.c")
-set(requires "esp_eth" "esp_netif" "esp_wifi" "esp_timer" "nvs_flash" "esp_modem")
+set(requires "esp_eth" "esp_netif" "esp_wifi" "esp_timer" "nvs_flash" "esp_modem" "esp_driver_gpio")
 set(include_dirs "include")
 
 if("${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}" VERSION_GREATER_EQUAL "5.4.0")


### PR DESCRIPTION
Include esp_driver_gpio in components/iot_bridge/CMakeLists.txt requires list so the iot_bridge component links against the GPIO driver. This ensures GPIO driver symbols are available during build for code that depends on esp_driver_gpio.

# Checklist for new Board Support package or Component

- [x] Component contains License
- [ ] Component contains README.md
- [ ] Project [README.md](../README.md) updated
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to CI [upload job](https://github.com/espressif/esp-iot-bridge/blob/master/.github/workflows/upload_component.yml#L17)
- [ ] New files were added to CI build job
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
